### PR TITLE
Remove nvshmem dependency, as Windows is not supported

### DIFF
--- a/flashinfer/jit/env.py
+++ b/flashinfer/jit/env.py
@@ -20,6 +20,7 @@ limitations under the License.
 
 import os
 import pathlib
+import platform
 import re
 import warnings
 
@@ -70,6 +71,9 @@ def get_nvshmem_include_dirs():
     if paths is not None:
         return [pathlib.Path(p) for p in paths.split(os.pathsep) if p]
 
+    if platform.system() == "Windows":
+        raise NotImplementedError("NVSHMEM library does not support Windows")
+
     import nvidia.nvshmem
 
     path = pathlib.Path(nvidia.nvshmem.__path__[0]) / "include"
@@ -80,6 +84,9 @@ def get_nvshmem_lib_dirs():
     paths = os.environ.get("NVSHMEM_LIBRARY_PATH")
     if paths is not None:
         return [pathlib.Path(p) for p in paths.split(os.pathsep) if p]
+
+    if platform.system() == "Windows":
+        raise NotImplementedError("NVSHMEM library does not support Windows")
 
     import nvidia.nvshmem
 

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,6 @@ install_requires = [
     "cuda-python",
     "pynvml",
     "einops",
-    "nvidia-nvshmem-cu12",
 ]
 generate_build_meta({})
 


### PR DESCRIPTION
`nvidia-nvshmem-cu12` was introduced in flashinfer `0.2.7` as a dependency. But `nvshmem` doesn't support Windows, thus prevents wheel installation.

This pr removes it from python package dependency in setup.py, and adds checks for better error information instead of an import error (doesn't seem this library is currently being used in flashinfer though).